### PR TITLE
feat: improve DID resolution error handling and testing

### DIFF
--- a/examples/key-did.ts
+++ b/examples/key-did.ts
@@ -1,0 +1,21 @@
+import { resolveDid } from "../src/resolve-did"
+
+async function main() {
+  try {
+    // Resolve a secp256k1 key-based DID
+    const secp256k1Did = "did:key:zQ3shNCcRrVT3tm43o6JNjSjQaiBXvSb8kHtFhoNGR8eimFZs"
+    console.log("\nResolving secp256k1 DID:", secp256k1Did)
+    const { didDocument: secp256k1Doc } = await resolveDid(secp256k1Did)
+    console.log("DID Document:", JSON.stringify(secp256k1Doc, null, 2))
+
+    // Resolve an Ed25519 key-based DID
+    const ed25519Did = "did:key:z6MknEES6VA14awWdV27ab5r1jtz3d6ct2wULmvU4YgE1wQ8"
+    console.log("\nResolving Ed25519 DID:", ed25519Did)
+    const { didDocument: ed25519Doc } = await resolveDid(ed25519Did)
+    console.log("DID Document:", JSON.stringify(ed25519Doc, null, 2))
+  } catch (error) {
+    console.error("Error:", error)
+  }
+}
+
+main()

--- a/examples/pkh-did.ts
+++ b/examples/pkh-did.ts
@@ -1,0 +1,15 @@
+import { resolveDid } from "../src/resolve-did"
+
+async function main() {
+  try {
+    // Resolve an Ethereum address DID
+    const ethDid = "did:pkh:eip155:1:0x0000000000000000000000000000000000000000"
+    console.log("Resolving Ethereum DID:", ethDid)
+    const { didDocument } = await resolveDid(ethDid)
+    console.log("DID Document:", JSON.stringify(didDocument, null, 2))
+  } catch (error) {
+    console.error("Error:", error)
+  }
+}
+
+main()

--- a/examples/web-did.ts
+++ b/examples/web-did.ts
@@ -1,0 +1,14 @@
+import { resolveDid } from "../src/resolve-did"
+
+async function main() {
+  try {
+    // Resolve a web-based DID
+    const { did, didDocument } = await resolveDid("did:web:venabl.es")
+    console.log("Resolved DID:", did)
+    console.log("DID Document:", JSON.stringify(didDocument, null, 2))
+  } catch (error) {
+    console.error("Error:", error)
+  }
+}
+
+main()

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { main, parseArgs } from "./cli"
+
+describe("CLI", () => {
+  const originalExit = process.exit
+  const mockExit = vi.fn()
+
+  beforeEach(() => {
+    process.exit = mockExit as never
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.spyOn(console, "log").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.exit = originalExit
+    vi.restoreAllMocks()
+  })
+
+  describe("parseArgs", () => {
+    it("should parse DID URI from arguments", () => {
+      const args = ["node", "resolve-did", "did:web:example.com"]
+      const options = parseArgs(args)
+      expect(options.didUri).toBe("did:web:example.com")
+    })
+
+    it("should parse --raw flag", () => {
+      const args = ["node", "resolve-did", "did:web:example.com", "--raw"]
+      const options = parseArgs(args)
+      expect(options.raw).toBe(true)
+    })
+
+    it("should parse --help flag", () => {
+      const args = ["node", "resolve-did", "--help"]
+      const options = parseArgs(args)
+      expect(options.help).toBe(true)
+    })
+  })
+
+  it("should show help message when --help flag is used", async () => {
+    await main(["node", "resolve-did", "--help"])
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Usage:"))
+    expect(mockExit).toHaveBeenCalledWith(0)
+  })
+
+  it("should show error for missing DID URI", async () => {
+    await main(["node", "resolve-did"])
+    expect(console.error).toHaveBeenCalledWith("Missing DID URI")
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it("should show error for invalid DID URI", async () => {
+    await main(["node", "resolve-did", "not-a-did"])
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid DID URI")
+    )
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it("should show error for unsupported DID method", async () => {
+    await main(["node", "resolve-did", "did:unknown:123"])
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Unsupported DID method")
+    )
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it("should resolve valid DID URI", async () => {
+    await main(["node", "resolve-did", "did:web:venabl.es"])
+    expect(console.log).toHaveBeenCalled()
+    expect(mockExit).toHaveBeenCalledWith(0)
+  })
+})

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,24 +2,110 @@
 
 import { inspect } from "node:util"
 import { resolveDid } from "./resolve-did"
+import { DidResolutionError } from "./errors"
+import {
+  InvalidDidError,
+  UnsupportedDidMethodError,
+  DidNotFoundError
+} from "./errors"
 
-async function main(didUri?: string) {
-  if (!didUri) {
-    console.error("Usage: npx resolve-did <did-uri>")
-    process.exit(1)
-  }
+const HELP_MESSAGE = `
+Usage: npx resolve-did <did-uri> [options]
 
-  const { didDocument } = await resolveDid(didUri)
-  console.log(
-    inspect(didDocument, { colors: true, depth: null, compact: false })
-  )
+Options:
+  --help     Show this help message
+  --raw      Output raw JSON without formatting
+
+Examples:
+  # Resolve a web-based DID
+  npx resolve-did did:web:example.com
+
+  # Resolve a key-based DID
+  npx resolve-did did:key:z6MknEES6VA14awWdV27ab5r1jtz3d6ct2wULmvU4YgE1wQ8
+
+  # Resolve an Ethereum address
+  npx resolve-did did:pkh:eip155:1:0x0000000000000000000000000000000000000000
+
+  # Output raw JSON
+  npx resolve-did did:web:example.com --raw
+`
+
+interface CliOptions {
+  didUri?: string
+  raw: boolean
+  help: boolean
 }
 
-main(process.argv[2])
-  .then(() => {
+/**
+ * Parse command line arguments into options.
+ * @param args - Command line arguments
+ * @returns Parsed options
+ */
+export function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    raw: false,
+    help: false
+  }
+
+  for (let i = 2; i < args.length; i++) {
+    const arg = args[i] ?? ""
+    if (arg === "--help") {
+      options.help = true
+    } else if (arg === "--raw") {
+      options.raw = true
+    } else if (!arg.startsWith("--")) {
+      options.didUri = arg
+    }
+  }
+
+  return options
+}
+
+/**
+ * Main CLI function that handles argument parsing and DID resolution.
+ * @param args - Command line arguments
+ */
+export async function main(args: string[] = process.argv): Promise<void> {
+  try {
+    const options = parseArgs(args)
+
+    if (options.help) {
+      console.log(HELP_MESSAGE)
+      process.exit(0)
+    }
+
+    if (!options.didUri) {
+      console.error("Missing DID URI")
+      console.error("\nUsage: npx resolve-did <did-uri> [options]")
+      console.error("Try 'npx resolve-did --help' for more information")
+      process.exit(1)
+    }
+
+    const { didDocument } = await resolveDid(options.didUri)
+    console.log(
+      options.raw
+        ? JSON.stringify(didDocument)
+        : JSON.stringify(didDocument, null, 2)
+    )
     process.exit(0)
-  })
-  .catch((error: unknown) => {
-    console.error(error)
+  } catch (error) {
+    if (error instanceof InvalidDidError) {
+      console.error(`Invalid DID URI: ${error.message}`)
+    } else if (error instanceof UnsupportedDidMethodError) {
+      console.error(`Unsupported DID method: ${error.message}`)
+    } else if (error instanceof DidNotFoundError) {
+      console.error(`DID not found: ${error.message}`)
+    } else {
+      console.error("Fatal error:", error)
+    }
+    process.exit(1)
+  }
+}
+
+// Run if called directly
+if (process.argv[1] === import.meta.url) {
+  main().catch((error: unknown) => {
+    console.error("Fatal error:", error)
     process.exit(1)
   })
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,79 @@
+/**
+ * Base error class for DID resolution errors.
+ * All specific DID resolution errors should extend this class.
+ *
+ * @class
+ * @extends Error
+ */
+export class DidResolutionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
+/**
+ * Thrown when the input DID URI is invalid.
+ * This can happen when:
+ * - The input is not a string
+ * - The string doesn't start with "did:"
+ * - The DID method is missing
+ *
+ * @example
+ * ```ts
+ * // Invalid DID format
+ * throw new InvalidDidError("notadid")
+ * // Invalid DID method
+ * throw new InvalidDidError("did:unknown:123")
+ * ```
+ *
+ * @class
+ * @extends DidResolutionError
+ */
+export class InvalidDidError extends DidResolutionError {
+  constructor(did: string) {
+    super(`Invalid DID URI: "${did}". DID must be a valid URI string starting with "did:"`)
+  }
+}
+
+/**
+ * Thrown when the DID method is not supported by the resolver.
+ * Currently supported methods are:
+ * - did:web - Web-based DIDs
+ * - did:key - Key-based DIDs (secp256k1 and Ed25519)
+ * - did:pkh - Public Key Hash DIDs (Ethereum addresses)
+ *
+ * @example
+ * ```ts
+ * throw new UnsupportedDidMethodError("unknown")
+ * ```
+ *
+ * @class
+ * @extends DidResolutionError
+ */
+export class UnsupportedDidMethodError extends DidResolutionError {
+  constructor(method: string) {
+    super(`Unsupported DID method: "${method}". Supported methods are: web, key, pkh`)
+  }
+}
+
+/**
+ * Thrown when the DID document cannot be retrieved.
+ * This can happen when:
+ * - The DID doesn't exist
+ * - The DID document is not accessible (e.g., network error)
+ * - The DID document is malformed
+ *
+ * @example
+ * ```ts
+ * throw new DidNotFoundError("did:web:nonexistent.com")
+ * ```
+ *
+ * @class
+ * @extends DidResolutionError
+ */
+export class DidNotFoundError extends DidResolutionError {
+  constructor(did: string) {
+    super(`DID not found: "${did}". Check that the DID exists and is accessible`)
+  }
+}

--- a/src/resolve-did.ts
+++ b/src/resolve-did.ts
@@ -5,26 +5,59 @@ import {
   type DidDocument,
   type DidUri
 } from "@agentcommercekit/did"
+import {
+  InvalidDidError,
+  DidNotFoundError,
+  UnsupportedDidMethodError
+} from "./errors"
+
+const SUPPORTED_METHODS = ["web", "key", "pkh"]
 
 /**
- * Resolve a did URI
+ * Resolves a DID URI to its DID Document.
  *
- * @param didUri - The did URI to resolve
- * @param resolver - The resolver to use
- * @returns An object containing the `did` and the `didDocument`
+ * This function takes a DID URI and returns the corresponding DID Document.
+ * It supports the following DID methods:
+ * - did:web - Web-based DIDs (e.g., did:web:example.com)
+ * - did:key - Key-based DIDs (secp256k1 and Ed25519)
+ * - did:pkh - Public Key Hash DIDs (Ethereum addresses)
+ *
+ * @example
+ * ```ts
+ * // Resolve a web-based DID
+ * const { did, didDocument } = await resolveDid("did:web:example.com")
+ *
+ * // Resolve a key-based DID (Ed25519)
+ * const { did, didDocument } = await resolveDid("did:key:z6MknEES6VA14awWdV27ab5r1jtz3d6ct2wULmvU4YgE1wQ8")
+ *
+ * // Resolve an Ethereum address
+ * const { did, didDocument } = await resolveDid("did:pkh:eip155:1:0x123...")
+ * ```
+ *
+ * @param didUri - The DID URI to resolve (e.g., "did:web:example.com")
+ * @param resolver - Optional custom DID resolver (defaults to Agent Commerce Kit resolver)
+ * @returns Object containing the DID and its resolved DID Document
+ * @throws {InvalidDidError} If the DID URI is invalid or malformed
+ * @throws {UnsupportedDidMethodError} If the DID method is not supported
+ * @throws {DidNotFoundError} If the DID cannot be resolved or accessed
  */
 export async function resolveDid(
   didUri: unknown,
   resolver = getDidResolver()
 ): Promise<{ did: DidUri; didDocument: DidDocument }> {
   if (!isDidUri(didUri)) {
-    throw new Error("Invalid DID URI")
+    throw new InvalidDidError(String(didUri))
   }
 
-  const { did, didDocument } = await ackResolveDid(didUri, resolver)
+  const method = String(didUri).split(":")[1]
+  if (!SUPPORTED_METHODS.includes(method)) {
+    throw new UnsupportedDidMethodError(method)
+  }
 
-  return {
-    did,
-    didDocument
+  try {
+    const { did, didDocument } = await ackResolveDid(didUri, resolver)
+    return { did, didDocument }
+  } catch (error) {
+    throw new DidNotFoundError(String(didUri))
   }
 }


### PR DESCRIPTION
Better error handling for DID resolution

Added specific error types to help users quickly identify issues:
- InvalidDidError: For malformed DIDs
- UnsupportedDidMethodError: When method isn't web/key/pkh
- DidNotFoundError: When DID exists but can't be resolved

Added tests:
- CLI integration tests with proper mocking
- Error case coverage
- Example files showing usage for each method